### PR TITLE
Fix scaling in Interface Builder

### DIFF
--- a/Example/AppDelegate.swift
+++ b/Example/AppDelegate.swift
@@ -4,8 +4,7 @@ import CircularProgress
 @NSApplicationMain
 final class AppDelegate: NSObject, NSApplicationDelegate {
 	@IBOutlet private var window: NSWindow!
-
-	let circularProgress = CircularProgress(size: 200)
+	@IBOutlet var circularProgress: CircularProgress!
 
 	func applicationWillFinishLaunching(_ notification: Notification) {
 		window.isMovableByWindowBackground = true
@@ -14,11 +13,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 	}
 
 	func applicationDidFinishLaunching(_ notification: Notification) {
-		let view = window.contentView!
-
-		circularProgress.frame = circularProgress.frame.centered(in: view.bounds)
 		circularProgress.showCheckmarkAtHundredPercent = true
-		view.addSubview(circularProgress)
 
 		animateWithRandomColor()
 	}

--- a/Example/Base.lproj/MainMenu.xib
+++ b/Example/Base.lproj/MainMenu.xib
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="14313.18" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="14460.31" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
     <dependencies>
         <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="14313.18"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="14460.31"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -15,6 +15,7 @@
         <customObject id="-3" userLabel="Application" customClass="NSObject"/>
         <customObject id="Voe-Tx-rLC" customClass="AppDelegate" customModule="CircularProgressExample" customModuleProvider="target">
             <connections>
+                <outlet property="circularProgress" destination="SMF-pk-TSv" id="f6e-4m-pcp"/>
                 <outlet property="window" destination="qrA-6v-96X" id="o33-hG-5om"/>
             </connections>
         </customObject>
@@ -70,10 +71,23 @@
             <windowCollectionBehavior key="collectionBehavior" fullScreenNone="YES"/>
             <windowPositionMask key="initialPositionMask" leftStrut="YES" rightStrut="YES" topStrut="YES" bottomStrut="YES"/>
             <rect key="contentRect" x="131" y="158" width="440" height="280"/>
-            <rect key="screenRect" x="0.0" y="0.0" width="1440" height="877"/>
+            <rect key="screenRect" x="0.0" y="0.0" width="2560" height="1417"/>
             <view key="contentView" id="NR7-Ty-MDa">
                 <rect key="frame" x="0.0" y="0.0" width="440" height="280"/>
                 <autoresizingMask key="autoresizingMask"/>
+                <subviews>
+                    <customView translatesAutoresizingMaskIntoConstraints="NO" id="SMF-pk-TSv" customClass="CircularProgress" customModule="CircularProgress">
+                        <rect key="frame" x="120" y="40" width="200" height="200"/>
+                        <constraints>
+                            <constraint firstAttribute="height" constant="200" id="8OA-5t-VSk"/>
+                            <constraint firstAttribute="width" constant="200" id="LB3-DI-RwH"/>
+                        </constraints>
+                    </customView>
+                </subviews>
+                <constraints>
+                    <constraint firstItem="SMF-pk-TSv" firstAttribute="centerY" secondItem="NR7-Ty-MDa" secondAttribute="centerY" id="b6t-f1-BUn"/>
+                    <constraint firstItem="SMF-pk-TSv" firstAttribute="centerX" secondItem="NR7-Ty-MDa" secondAttribute="centerX" id="cBs-wu-43p"/>
+                </constraints>
             </view>
             <point key="canvasLocation" x="208" y="502"/>
         </window>

--- a/Sources/CircularProgress/CircularProgress.swift
+++ b/Sources/CircularProgress/CircularProgress.swift
@@ -116,12 +116,11 @@ public final class CircularProgress: NSView {
 		layer?.addSublayer(progressLabel)
 	}
 
+	#if TARGET_INTERFACE_BUILDER
 	public override func viewDidMoveToWindow() {
 		super.viewDidMoveToWindow()
 
-		#if TARGET_INTERFACE_BUILDER
 		enforceAspectRatio()
-		#endif
 	}
 
 	private func enforceAspectRatio() {
@@ -133,6 +132,7 @@ public final class CircularProgress: NSView {
 										 multiplier: 1,
 										 constant: 0))
 	}
+	#endif
 
 	/**
 	Reset the progress back to zero without animating.

--- a/Sources/CircularProgress/CircularProgress.swift
+++ b/Sources/CircularProgress/CircularProgress.swift
@@ -20,9 +20,10 @@ public final class CircularProgress: NSView {
 
 	private lazy var progressLabel = with(CATextLayer(text: "0%")) {
 		$0.color = color
-		$0.frame = bounds
 		$0.fontSize = bounds.width * 0.2
-		$0.position.y = bounds.midY * 0.25
+		$0.frame = CGRect(x: 0, y: 0, width: bounds.width, height: $0.preferredFrameSize().height)
+		$0.position = CGPoint(x: bounds.midX, y: bounds.midY)
+		$0.anchorPoint = CGPoint(x: 0.5, y: 0.5)
 		$0.alignmentMode = .center
 		$0.font = NSFont.helveticaNeueLight // Not using the system font as it has too much number width variance
 	}
@@ -113,6 +114,24 @@ public final class CircularProgress: NSView {
 		layer?.addSublayer(backgroundCircle)
 		layer?.addSublayer(progressCircle)
 		layer?.addSublayer(progressLabel)
+	}
+
+	public override func viewDidMoveToWindow() {
+		super.viewDidMoveToWindow()
+
+		#if TARGET_INTERFACE_BUILDER
+		enforceAspectRatio()
+		#endif
+	}
+
+	private func enforceAspectRatio() {
+		addConstraint(NSLayoutConstraint(item: self,
+										 attribute: .height,
+										 relatedBy: .equal,
+										 toItem: self,
+										 attribute: .width,
+										 multiplier: 1,
+										 constant: 0))
 	}
 
 	/**

--- a/Sources/CircularProgress/CircularProgress.swift
+++ b/Sources/CircularProgress/CircularProgress.swift
@@ -116,24 +116,6 @@ public final class CircularProgress: NSView {
 		layer?.addSublayer(progressLabel)
 	}
 
-	#if TARGET_INTERFACE_BUILDER
-	public override func viewDidMoveToWindow() {
-		super.viewDidMoveToWindow()
-
-		enforceAspectRatio()
-	}
-
-	private func enforceAspectRatio() {
-		addConstraint(NSLayoutConstraint(item: self,
-										 attribute: .height,
-										 relatedBy: .equal,
-										 toItem: self,
-										 attribute: .width,
-										 multiplier: 1,
-										 constant: 0))
-	}
-	#endif
-
 	/**
 	Reset the progress back to zero without animating.
 	*/

--- a/Sources/CircularProgress/CircularProgress.swift
+++ b/Sources/CircularProgress/CircularProgress.swift
@@ -3,7 +3,7 @@ import Cocoa
 @IBDesignable
 public final class CircularProgress: NSView {
 	private var lineWidth: Double = 2
-	private lazy var radius = bounds.midX * 0.8
+	private lazy var radius = bounds.width < bounds.height ? bounds.midX * 0.8 : bounds.midY * 0.8
 	private var _progress: Double = 0
 	private var progressObserver: NSKeyValueObservation?
 
@@ -20,7 +20,7 @@ public final class CircularProgress: NSView {
 
 	private lazy var progressLabel = with(CATextLayer(text: "0%")) {
 		$0.color = color
-		$0.fontSize = bounds.width * 0.2
+		$0.fontSize = bounds.width < bounds.height ? bounds.width * 0.2 : bounds.height * 0.2
 		$0.frame = CGRect(x: 0, y: 0, width: bounds.width, height: $0.preferredFrameSize().height)
 		$0.position = CGPoint(x: bounds.midX, y: bounds.midY)
 		$0.anchorPoint = CGPoint(x: 0.5, y: 0.5)


### PR DESCRIPTION
As requested in https://github.com/sindresorhus/CircularProgress/issues/2. 

~~This keeps the aspect ratio by adding a layout constraint specifically for IB.~~ ✨
The layout constraint is no longer necessary as the progress view now scales properly, regardless of the aspect ratio. 🎉

![resize](https://user-images.githubusercontent.com/225410/51540463-c99c5f80-1e56-11e9-8943-a599e5a19e9c.gif)
