### PR TITLE
Add ability to cancel the progress

### DIFF
--- a/CircularProgress.xcodeproj/project.pbxproj
+++ b/CircularProgress.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		B5344AB721F8B27100C12ADB /* CustomButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5344AB621F8B27100C12ADB /* CustomButton.swift */; };
 		E327393D2177359E00FFE124 /* util.swift in Sources */ = {isa = PBXBuildFile; fileRef = E327393C2177359E00FFE124 /* util.swift */; };
 		E3FB30C420EA5DBC009BA1BD /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = E3FB30C320EA5DBC009BA1BD /* AppDelegate.swift */; };
 		E3FB30C920EA5DBE009BA1BD /* MainMenu.xib in Resources */ = {isa = PBXBuildFile; fileRef = E3FB30C720EA5DBE009BA1BD /* MainMenu.xib */; };
@@ -42,6 +43,7 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		B5344AB621F8B27100C12ADB /* CustomButton.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CustomButton.swift; sourceTree = "<group>"; };
 		"CircularProgress::CircularProgress::Product" /* CircularProgress.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = CircularProgress.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		E327393C2177359E00FFE124 /* util.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; lineEnding = 0; path = util.swift; sourceTree = "<group>"; usesTabs = 1; };
 		E3FB30C120EA5DBC009BA1BD /* CircularProgressExample.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = CircularProgressExample.app; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -115,6 +117,7 @@
 			isa = PBXGroup;
 			children = (
 				OBJ_9 /* CircularProgress.swift */,
+				B5344AB621F8B27100C12ADB /* CustomButton.swift */,
 				OBJ_10 /* util.swift */,
 			);
 			name = CircularProgress;
@@ -260,6 +263,7 @@
 			files = (
 				OBJ_19 /* CircularProgress.swift in Sources */,
 				OBJ_20 /* util.swift in Sources */,
+				B5344AB721F8B27100C12ADB /* CustomButton.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/CircularProgress.xcodeproj/xcshareddata/xcschemes/CircularProgressExample.xcscheme
+++ b/CircularProgress.xcodeproj/xcshareddata/xcschemes/CircularProgressExample.xcscheme
@@ -1,0 +1,91 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1010"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "E3FB30C020EA5DBC009BA1BD"
+               BuildableName = "CircularProgressExample.app"
+               BlueprintName = "CircularProgressExample"
+               ReferencedContainer = "container:CircularProgress.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+      </Testables>
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "E3FB30C020EA5DBC009BA1BD"
+            BuildableName = "CircularProgressExample.app"
+            BlueprintName = "CircularProgressExample"
+            ReferencedContainer = "container:CircularProgress.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "E3FB30C020EA5DBC009BA1BD"
+            BuildableName = "CircularProgressExample.app"
+            BlueprintName = "CircularProgressExample"
+            ReferencedContainer = "container:CircularProgress.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "E3FB30C020EA5DBC009BA1BD"
+            BuildableName = "CircularProgressExample.app"
+            BlueprintName = "CircularProgressExample"
+            ReferencedContainer = "container:CircularProgress.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/CircularProgress.xcodeproj/xcshareddata/xcschemes/CircularProgressPackageDescription.xcscheme
+++ b/CircularProgress.xcodeproj/xcshareddata/xcschemes/CircularProgressPackageDescription.xcscheme
@@ -15,7 +15,7 @@
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "CircularProgress::SwiftPMPackageDescription"
-               BuildableName = "CircularProgressPackageDescription.framework"
+               BuildableName = "CircularProgressPackageDescription"
                BlueprintName = "CircularProgressPackageDescription"
                ReferencedContainer = "container:CircularProgress.xcodeproj">
             </BuildableReference>

--- a/CircularProgress.xcodeproj/xcshareddata/xcschemes/CircularProgressPackageDescription.xcscheme
+++ b/CircularProgress.xcodeproj/xcshareddata/xcschemes/CircularProgressPackageDescription.xcscheme
@@ -1,0 +1,80 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1010"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "CircularProgress::SwiftPMPackageDescription"
+               BuildableName = "CircularProgressPackageDescription.framework"
+               BlueprintName = "CircularProgressPackageDescription"
+               ReferencedContainer = "container:CircularProgress.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+      </Testables>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "CircularProgress::SwiftPMPackageDescription"
+            BuildableName = "CircularProgressPackageDescription"
+            BlueprintName = "CircularProgressPackageDescription"
+            ReferencedContainer = "container:CircularProgress.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "CircularProgress::SwiftPMPackageDescription"
+            BuildableName = "CircularProgressPackageDescription"
+            BlueprintName = "CircularProgressPackageDescription"
+            ReferencedContainer = "container:CircularProgress.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/Example/AppDelegate.swift
+++ b/Example/AppDelegate.swift
@@ -23,12 +23,13 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 	}
 
 	private func configureManualView() {
-		manualCircularProgress.onCancelled = {
-			print("Manual cancelled!")
+		manualCircularProgress.onCancelled = { circularProgress in
+			circularProgress.alphaValue = 0.3
 		}
 
 		animateWithRandomColor(manualCircularProgress, start: { circularProgress in
 
+			circularProgress.alphaValue = 1.0
 			circularProgress.resetProgress()
 
 		}, tick: { circularProgress in
@@ -40,12 +41,13 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 	}
 
 	private func configureProgressBasedView() {
-		progressCircularProgress.onCancelled = {
-			print("Progress cancelled!")
+		progressCircularProgress.onCancelled = { circularProgress in
+			circularProgress.alphaValue = 0.3
 		}
 
 		animateWithRandomColor(progressCircularProgress, start: { circularProgress in
 
+			circularProgress.alphaValue = 1.0
 			circularProgress.resetProgress()
 
 			let progress = Progress(totalUnitCount: 50)

--- a/Example/AppDelegate.swift
+++ b/Example/AppDelegate.swift
@@ -27,17 +27,16 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 			circularProgress.alphaValue = 0.3
 		}
 
-		animateWithRandomColor(manualCircularProgress, start: { circularProgress in
-
-			circularProgress.alphaValue = 1.0
-			circularProgress.resetProgress()
-
-		}, tick: { circularProgress in
-
-			circularProgress.progress += 0.01
-
-		})
-
+		animateWithRandomColor(
+			manualCircularProgress,
+			start: { circularProgress in
+				circularProgress.alphaValue = 1.0
+				circularProgress.resetProgress()
+			},
+			tick: { circularProgress in
+				circularProgress.progress += 0.01
+			}
+		)
 	}
 
 	private func configureProgressBasedView() {
@@ -45,22 +44,26 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 			circularProgress.alphaValue = 0.3
 		}
 
-		animateWithRandomColor(progressCircularProgress, start: { circularProgress in
+		animateWithRandomColor(
+			progressCircularProgress,
+			start: { circularProgress in
+				circularProgress.alphaValue = 1.0
+				circularProgress.resetProgress()
 
-			circularProgress.alphaValue = 1.0
-			circularProgress.resetProgress()
-
-			let progress = Progress(totalUnitCount: 50)
-			circularProgress.progressInstance = progress
-
-		}, tick: { circularProgress in
-
-			circularProgress.progressInstance?.completedUnitCount += 1
-
-		})
+				let progress = Progress(totalUnitCount: 50)
+				circularProgress.progressInstance = progress
+			},
+			tick: { circularProgress in
+				circularProgress.progressInstance?.completedUnitCount += 1
+			}
+		)
 	}
 
-	private func animateWithRandomColor(_ circularProgress: CircularProgress, start: @escaping (CircularProgress) -> Void, tick: @escaping (CircularProgress) -> Void) {
+	private func animateWithRandomColor(
+		_ circularProgress: CircularProgress,
+		start: @escaping (CircularProgress) -> Void,
+		tick: @escaping (CircularProgress
+	) -> Void) {
 		var startAnimating: (() -> Void)!
 		var timer: Timer!
 

--- a/Example/AppDelegate.swift
+++ b/Example/AppDelegate.swift
@@ -15,6 +15,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 	func applicationDidFinishLaunching(_ notification: Notification) {
 		circularProgress.showCheckmarkAtHundredPercent = true
 
+		circularProgress.onCancel = {
+			print("Should cancel")
+		}
+
 		animateWithRandomColor()
 	}
 

--- a/Example/AppDelegate.swift
+++ b/Example/AppDelegate.swift
@@ -62,8 +62,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 	private func animateWithRandomColor(
 		_ circularProgress: CircularProgress,
 		start: @escaping (CircularProgress) -> Void,
-		tick: @escaping (CircularProgress
-	) -> Void) {
+		tick: @escaping (CircularProgress) -> Void
+	) {
 		var startAnimating: (() -> Void)!
 		var timer: Timer!
 

--- a/Example/AppDelegate.swift
+++ b/Example/AppDelegate.swift
@@ -41,7 +41,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 
 	private func configureProgressBasedView() {
 		progressCircularProgress.onCancelled = {
-			self.manualCircularProgress.alphaValue = 0.3
+			self.progressCircularProgress.alphaValue = 0.3
 		}
 
 		animateWithRandomColor(

--- a/Example/AppDelegate.swift
+++ b/Example/AppDelegate.swift
@@ -23,8 +23,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 	}
 
 	private func configureManualView() {
-		manualCircularProgress.onCancelled = { circularProgress in
-			circularProgress.alphaValue = 0.3
+		manualCircularProgress.onCancelled = {
+			self.manualCircularProgress.alphaValue = 0.3
 		}
 
 		animateWithRandomColor(
@@ -40,8 +40,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 	}
 
 	private func configureProgressBasedView() {
-		progressCircularProgress.onCancelled = { circularProgress in
-			circularProgress.alphaValue = 0.3
+		progressCircularProgress.onCancelled = {
+			self.manualCircularProgress.alphaValue = 0.3
 		}
 
 		animateWithRandomColor(

--- a/Example/AppDelegate.swift
+++ b/Example/AppDelegate.swift
@@ -15,10 +15,6 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 	func applicationDidFinishLaunching(_ notification: Notification) {
 		circularProgress.showCheckmarkAtHundredPercent = true
 
-		circularProgress.onCancel = {
-			print("Should cancel")
-		}
-
 		animateWithRandomColor()
 	}
 
@@ -26,18 +22,21 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 		return true
 	}
 
-	func animateWithRandomColor() {
+	private func animateWithRandomColor() {
 		var startAnimating: (() -> Void)!
 		var timer: Timer!
 
 		startAnimating = {
+			let progress = Progress(totalUnitCount: 50)
+			self.circularProgress.progressInstance = progress
+
 			self.circularProgress.resetProgress()
 			self.circularProgress.color = NSColor.uniqueRandomSystemColor()
 
 			timer = Timer.scheduledTimer(withTimeInterval: 0.05, repeats: true) { _ in
-				self.circularProgress.progress += 0.01
+				progress.completedUnitCount += 1
 
-				if self.circularProgress.progress == 1 {
+				if progress.isFinished || progress.isCancelled {
 					timer.invalidate()
 
 					delay(seconds: 1) {

--- a/Example/Base.lproj/MainMenu.xib
+++ b/Example/Base.lproj/MainMenu.xib
@@ -69,7 +69,6 @@
         <window title="CircularProgress Example" allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" restorable="NO" releasedWhenClosed="NO" frameAutosaveName="" animationBehavior="default" tabbingMode="disallowed" titlebarAppearsTransparent="YES" titleVisibility="hidden" id="qrA-6v-96X">
             <windowStyleMask key="styleMask" titled="YES" closable="YES" miniaturizable="YES" fullSizeContentView="YES"/>
             <windowCollectionBehavior key="collectionBehavior" fullScreenNone="YES"/>
-            <windowPositionMask key="initialPositionMask" leftStrut="YES" rightStrut="YES" topStrut="YES" bottomStrut="YES"/>
             <rect key="contentRect" x="131" y="158" width="440" height="280"/>
             <rect key="screenRect" x="0.0" y="0.0" width="2560" height="1417"/>
             <view key="contentView" id="NR7-Ty-MDa">

--- a/Example/Base.lproj/MainMenu.xib
+++ b/Example/Base.lproj/MainMenu.xib
@@ -15,7 +15,8 @@
         <customObject id="-3" userLabel="Application" customClass="NSObject"/>
         <customObject id="Voe-Tx-rLC" customClass="AppDelegate" customModule="CircularProgressExample" customModuleProvider="target">
             <connections>
-                <outlet property="circularProgress" destination="SMF-pk-TSv" id="f6e-4m-pcp"/>
+                <outlet property="manualCircularProgress" destination="Xhy-S9-VRc" id="arP-3C-To1"/>
+                <outlet property="progressCircularProgress" destination="w1Y-Wj-BvT" id="Fg3-nC-1Ys"/>
                 <outlet property="window" destination="qrA-6v-96X" id="o33-hG-5om"/>
             </connections>
         </customObject>
@@ -69,23 +70,49 @@
         <window title="CircularProgress Example" allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" restorable="NO" releasedWhenClosed="NO" frameAutosaveName="" animationBehavior="default" tabbingMode="disallowed" titlebarAppearsTransparent="YES" titleVisibility="hidden" id="qrA-6v-96X">
             <windowStyleMask key="styleMask" titled="YES" closable="YES" miniaturizable="YES" fullSizeContentView="YES"/>
             <windowCollectionBehavior key="collectionBehavior" fullScreenNone="YES"/>
-            <rect key="contentRect" x="131" y="158" width="440" height="280"/>
+            <rect key="contentRect" x="131" y="158" width="440" height="300"/>
             <rect key="screenRect" x="0.0" y="0.0" width="2560" height="1417"/>
             <view key="contentView" id="NR7-Ty-MDa">
-                <rect key="frame" x="0.0" y="0.0" width="440" height="280"/>
+                <rect key="frame" x="0.0" y="0.0" width="440" height="300"/>
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
-                    <customView translatesAutoresizingMaskIntoConstraints="NO" id="SMF-pk-TSv" customClass="CircularProgress" customModule="CircularProgress">
-                        <rect key="frame" x="120" y="40" width="200" height="200"/>
+                    <customView translatesAutoresizingMaskIntoConstraints="NO" id="Xhy-S9-VRc" customClass="CircularProgress" customModule="CircularProgress">
+                        <rect key="frame" x="20" y="50" width="200" height="200"/>
                         <constraints>
-                            <constraint firstAttribute="height" constant="200" id="8OA-5t-VSk"/>
-                            <constraint firstAttribute="width" constant="200" id="LB3-DI-RwH"/>
+                            <constraint firstAttribute="width" constant="200" id="F4V-GI-CZs"/>
+                            <constraint firstAttribute="height" constant="200" id="Uu5-lc-rUj"/>
+                        </constraints>
+                        <userDefinedRuntimeAttributes>
+                            <userDefinedRuntimeAttribute type="number" keyPath="progress">
+                                <real key="value" value="0.0"/>
+                            </userDefinedRuntimeAttribute>
+                        </userDefinedRuntimeAttributes>
+                    </customView>
+                    <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="lSV-Ki-zTa">
+                        <rect key="frame" x="74" y="38" width="93" height="18"/>
+                        <buttonCell key="cell" type="check" title="Cancellable" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="a9K-wg-1zs">
+                            <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
+                            <font key="font" metaFont="system"/>
+                        </buttonCell>
+                        <connections>
+                            <binding destination="Voe-Tx-rLC" name="value" keyPath="manualCircularProgress.isCancellable" id="C7e-AQ-sqW"/>
+                        </connections>
+                    </button>
+                    <customView translatesAutoresizingMaskIntoConstraints="NO" id="w1Y-Wj-BvT" customClass="CircularProgress" customModule="CircularProgress">
+                        <rect key="frame" x="220" y="50" width="200" height="200"/>
+                        <constraints>
+                            <constraint firstAttribute="width" constant="200" id="o6o-0R-3ld"/>
+                            <constraint firstAttribute="height" constant="200" id="wnt-rv-UYT"/>
                         </constraints>
                     </customView>
                 </subviews>
                 <constraints>
-                    <constraint firstItem="SMF-pk-TSv" firstAttribute="centerY" secondItem="NR7-Ty-MDa" secondAttribute="centerY" id="b6t-f1-BUn"/>
-                    <constraint firstItem="SMF-pk-TSv" firstAttribute="centerX" secondItem="NR7-Ty-MDa" secondAttribute="centerX" id="cBs-wu-43p"/>
+                    <constraint firstItem="lSV-Ki-zTa" firstAttribute="centerX" secondItem="Xhy-S9-VRc" secondAttribute="centerX" id="9gn-kh-Bt6"/>
+                    <constraint firstItem="w1Y-Wj-BvT" firstAttribute="centerY" secondItem="NR7-Ty-MDa" secondAttribute="centerY" id="J1e-dd-P63"/>
+                    <constraint firstItem="Xhy-S9-VRc" firstAttribute="centerY" secondItem="NR7-Ty-MDa" secondAttribute="centerY" id="Yok-5s-sGU"/>
+                    <constraint firstItem="w1Y-Wj-BvT" firstAttribute="centerX" secondItem="NR7-Ty-MDa" secondAttribute="centerX" constant="100" id="iuz-Bf-AV5"/>
+                    <constraint firstItem="Xhy-S9-VRc" firstAttribute="centerX" secondItem="NR7-Ty-MDa" secondAttribute="centerX" constant="-100" id="jVm-sk-tQA"/>
+                    <constraint firstItem="lSV-Ki-zTa" firstAttribute="bottom" secondItem="Xhy-S9-VRc" secondAttribute="bottom" constant="10" id="mEX-K6-QkT"/>
                 </constraints>
             </view>
             <point key="canvasLocation" x="208" y="502"/>

--- a/Sources/CircularProgress/CircularProgress.swift
+++ b/Sources/CircularProgress/CircularProgress.swift
@@ -211,7 +211,7 @@ public final class CircularProgress: NSView {
 	/**
 	Triggers when the progress was cancelled succesfully.
 	*/
-	public var onCancelled: ((CircularProgress) -> Void)?
+	public var onCancelled: (() -> Void)?
 
 	public var _isCancellable = false
 	/**
@@ -247,7 +247,7 @@ public final class CircularProgress: NSView {
 			_isCancelled = newValue
 
 			if newValue {
-				onCancelled?(self)
+				onCancelled?()
 			}
 		}
 	}

--- a/Sources/CircularProgress/CircularProgress.swift
+++ b/Sources/CircularProgress/CircularProgress.swift
@@ -198,13 +198,14 @@ public final class CircularProgress: NSView {
 			isCancelled = true
 			return
 		}
+
 		progressInstance.cancel()
 	}
 
 	/**
 	Triggers when the progress was cancelled succesfully.
 	*/
-	public var onCancelled: (() -> Void)?
+	public var onCancelled: ((CircularProgress) -> Void)?
 
 	public var _isCancellable = false
 	/**
@@ -219,6 +220,7 @@ public final class CircularProgress: NSView {
 		}
 		set {
 			_isCancellable = newValue
+
 			updateTrackingAreas()
 		}
 	}
@@ -232,12 +234,14 @@ public final class CircularProgress: NSView {
 			if let progressInstance = progressInstance {
 				return progressInstance.isCancelled
 			}
+
 			return _isCancelled
 		}
 		set {
 			_isCancelled = newValue
+
 			if newValue {
-				onCancelled?()
+				onCancelled?(self)
 			}
 		}
 	}

--- a/Sources/CircularProgress/CircularProgress.swift
+++ b/Sources/CircularProgress/CircularProgress.swift
@@ -123,7 +123,7 @@ public final class CircularProgress: NSView {
 				}
 
 				finishedObserver = progressInstance.observe(\.isFinished) { sender, _ in
-					guard !sender.isCancelled && sender.isFinished else {
+					guard !self.isCancelled && sender.isFinished else {
 						return
 					}
 

--- a/Sources/CircularProgress/CircularProgress.swift
+++ b/Sources/CircularProgress/CircularProgress.swift
@@ -96,6 +96,7 @@ public final class CircularProgress: NSView {
 			if let progressInstance = progressInstance {
 				return progressInstance.isFinished
 			}
+
 			return _isFinished
 		}
 		set {
@@ -117,14 +118,18 @@ public final class CircularProgress: NSView {
 					guard !self.isCancelled && !sender.isFinished else {
 						return
 					}
+
 					self.progress = sender.fractionCompleted
 				}
+
 				finishedObserver = progressInstance.observe(\.isFinished) { sender, _ in
 					guard !sender.isCancelled && sender.isFinished else {
 						return
 					}
+
 					self.progress = 1
 				}
+
 				cancelledObserver = progressInstance.observe(\.isCancelled) { sender, _ in
 					self.isCancelled = sender.isCancelled
 				}
@@ -194,6 +199,7 @@ public final class CircularProgress: NSView {
 		guard isCancellable else {
 			return
 		}
+
 		guard let progressInstance = progressInstance else {
 			isCancelled = true
 			return
@@ -216,11 +222,11 @@ public final class CircularProgress: NSView {
 			if let progressInstance = progressInstance {
 				return progressInstance.isCancellable
 			}
+
 			return _isCancellable
 		}
 		set {
 			_isCancellable = newValue
-
 			updateTrackingAreas()
 		}
 	}

--- a/Sources/CircularProgress/CircularProgress.swift
+++ b/Sources/CircularProgress/CircularProgress.swift
@@ -155,8 +155,6 @@ public final class CircularProgress: NSView {
 
 	private var trackingArea: NSTrackingArea?
 
-	public typealias CancelClosure = (() -> Void)
-
 	override public func updateTrackingAreas() {
 		if let oldTrackingArea = trackingArea {
 			removeTrackingArea(oldTrackingArea)
@@ -167,7 +165,7 @@ public final class CircularProgress: NSView {
 		}
 
 		let newTrackingArea = NSTrackingArea(
-			rect: bounds,
+			rect: cancelButton.frame,
 			options: [
 				.mouseEnteredAndExited,
 				.activeInActiveApp

--- a/Sources/CircularProgress/CircularProgress.swift
+++ b/Sources/CircularProgress/CircularProgress.swift
@@ -88,6 +88,9 @@ public final class CircularProgress: NSView {
 	}
 
 	private var _isFinished = false
+	/**
+	Returns whether the progress is finished.
+	*/
 	@IBInspectable public private(set) var isFinished: Bool {
 		get {
 			if let progressInstance = progressInstance {
@@ -198,9 +201,15 @@ public final class CircularProgress: NSView {
 		progressInstance.cancel()
 	}
 
+	/**
+	Triggers when the progress was cancelled succesfully.
+	*/
 	public var onCancelled: (() -> Void)?
 
 	public var _isCancellable = false
+	/**
+	If the progress view is cancellable it shows the cancel button.
+	*/
 	@IBInspectable public var isCancellable: Bool {
 		get {
 			if let progressInstance = progressInstance {
@@ -215,6 +224,9 @@ public final class CircularProgress: NSView {
 	}
 
 	private var _isCancelled = false
+	/**
+	Returns whether the progress has been cancelled.
+	*/
 	@IBInspectable public private(set) var isCancelled: Bool {
 		get {
 			if let progressInstance = progressInstance {

--- a/Sources/CircularProgress/CircularProgress.swift
+++ b/Sources/CircularProgress/CircularProgress.swift
@@ -145,10 +145,7 @@ public final class CircularProgress: NSView {
 		progressLabel.string = "0%"
 	}
 
-	/**
-	Cancel the progress.
-	*/
-	public func cancelProgress() {
+	private func cancelProgress() {
 		progressInstance?.cancel()
 		resetProgress()
 	}

--- a/Sources/CircularProgress/CircularProgress.swift
+++ b/Sources/CircularProgress/CircularProgress.swift
@@ -162,7 +162,7 @@ public final class CircularProgress: NSView {
 			removeTrackingArea(oldTrackingArea)
 		}
 
-		guard onCancel != nil else {
+		guard progressInstance?.isCancellable != nil else {
 			return
 		}
 
@@ -180,14 +180,8 @@ public final class CircularProgress: NSView {
 		trackingArea = newTrackingArea
 	}
 
-	public var onCancel: CancelClosure? {
-		didSet {
-			updateTrackingAreas()
-		}
-	}
-
 	override public func mouseEntered(with event: NSEvent) {
-		guard onCancel != nil, progressInstance?.isCancellable ?? false else {
+		guard progressInstance?.isCancellable ?? false else {
 			super.mouseEntered(with: event)
 			return
 		}
@@ -197,7 +191,7 @@ public final class CircularProgress: NSView {
 	}
 
 	override public func mouseExited(with event: NSEvent) {
-		guard onCancel != nil, progressInstance?.isCancellable ?? false else {
+		guard progressInstance?.isCancellable ?? false else {
 			super.mouseExited(with: event)
 			return
 		}

--- a/Sources/CircularProgress/CustomButton.swift
+++ b/Sources/CircularProgress/CustomButton.swift
@@ -1,0 +1,327 @@
+import Cocoa
+
+// TODO(sindresorhus): I plan to extract this into a reusable package when it's more mature.
+
+extension CALayer {
+	// TODO: Find a way to use a strongly-typed KeyPath here.
+	// TODO: Accept NSColor instead of CGColor.
+	func animate(color: CGColor, keyPath: String, duration: Double) {
+		guard (value(forKey: keyPath) as! CGColor?) != color else {
+			return
+		}
+
+		let animation = CABasicAnimation(keyPath: keyPath)
+		animation.fromValue = value(forKey: keyPath)
+		animation.toValue = color
+		animation.duration = duration
+		animation.fillMode = .forwards
+		animation.isRemovedOnCompletion = false
+		add(animation, forKey: keyPath)
+		setValue(color, forKey: keyPath)
+	}
+}
+
+extension CGPoint {
+	func rounded(_ rule: FloatingPointRoundingRule = .toNearestOrAwayFromZero) -> CGPoint {
+		return CGPoint(x: x.rounded(rule), y: y.rounded(rule))
+	}
+}
+
+extension CGRect {
+	func roundedOrigin(_ rule: FloatingPointRoundingRule = .toNearestOrAwayFromZero) -> CGRect {
+		var rect = self
+		rect.origin = rect.origin.rounded(rule)
+		return rect
+	}
+}
+
+extension CGSize {
+	/// Returns a CGRect with `self` centered in it.
+	func centered(in rect: CGRect) -> CGRect {
+		return CGRect(
+			x: (rect.width - width) / 2,
+			y: (rect.height - height) / 2,
+			width: width,
+			height: height
+		)
+	}
+}
+
+// TODO: Add padding option
+@IBDesignable
+open class CustomButton: NSButton {
+	private let titleLayer = CATextLayer()
+	private var isMouseDown = false
+
+	static func circularButton(title: String, radius: Double, center: CGPoint) -> CustomButton {
+		return with(CustomButton()) {
+			$0.title = title
+			$0.frame = NSRect(x: Double(center.x) - radius, y: Double(center.y) - radius, width: radius * 2, height: radius * 2)
+			$0.cornerRadius = radius
+			$0.font = NSFont.systemFont(ofSize: CGFloat(radius * 2 / 3))
+		}
+	}
+
+	override open var wantsUpdateLayer: Bool {
+		return true
+	}
+
+	@IBInspectable override open var title: String {
+		didSet {
+			setTitle()
+		}
+	}
+
+	@IBInspectable public var textColor: NSColor = .white {
+		didSet {
+			needsDisplay = true
+			animateColor()
+		}
+	}
+
+	@IBInspectable public var activeTextColor: NSColor = .white {
+		didSet {
+			needsDisplay = true
+			animateColor()
+		}
+	}
+
+	@IBInspectable public var cornerRadius: Double = 4 {
+		didSet {
+			needsDisplay = true
+		}
+	}
+
+	@IBInspectable public var borderWidth: Double = 0 {
+		didSet {
+			needsDisplay = true
+		}
+	}
+
+	@IBInspectable public var borderColor: NSColor = .controlAccentColorPolyfill {
+		didSet {
+			needsDisplay = true
+			animateColor()
+		}
+	}
+
+	@IBInspectable public var activeBorderColor: NSColor = .controlAccentColorPolyfill {
+		didSet {
+			needsDisplay = true
+			animateColor()
+		}
+	}
+
+	@IBInspectable public var backgroundColor: NSColor = .controlAccentColorPolyfill {
+		didSet {
+			needsDisplay = true
+			animateColor()
+		}
+	}
+
+	@IBInspectable public var activeBackgroundColor: NSColor = .controlAccentColorPolyfill {
+		didSet {
+			needsDisplay = true
+			animateColor()
+		}
+	}
+
+	@IBInspectable public var shadowRadius: Double = 0 {
+		didSet {
+			needsDisplay = true
+			animateColor()
+		}
+	}
+
+	@IBInspectable public var activeShadowRadius: Double = -1 {
+		didSet {
+			needsDisplay = true
+			animateColor()
+		}
+	}
+
+	@IBInspectable public var shadowOpacity: Double = 0 {
+		didSet {
+			needsDisplay = true
+			animateColor()
+		}
+	}
+
+	@IBInspectable public var activeShadowOpacity: Double = -1 {
+		didSet {
+			needsDisplay = true
+			animateColor()
+		}
+	}
+
+	@IBInspectable public var shadowColor: NSColor = .controlShadowColor {
+		didSet {
+			needsDisplay = true
+			animateColor()
+		}
+	}
+
+	@IBInspectable public var activeShadowColor: NSColor? {
+		didSet {
+			needsDisplay = true
+			animateColor()
+		}
+	}
+
+	override open var font: NSFont? {
+		didSet {
+			setTitle()
+		}
+	}
+
+	override open var isEnabled: Bool {
+		didSet {
+			alphaValue = isEnabled ? 1 : 0.6
+		}
+	}
+
+	public convenience init() {
+		self.init(frame: .zero)
+	}
+
+	public required init?(coder: NSCoder) {
+		super.init(coder: coder)
+		setup()
+	}
+
+	override init(frame: CGRect) {
+		super.init(frame: frame)
+		setup()
+	}
+
+	// Ensure the button doesn't draw its default contents
+	override open func draw(_ dirtyRect: NSRect) {}
+	override open func drawFocusRingMask() {}
+
+	override open func layout() {
+		super.layout()
+		positionTitle()
+	}
+
+	override open func viewDidChangeBackingProperties() {
+		super.viewDidChangeBackingProperties()
+
+		if let scale = window?.backingScaleFactor {
+			layer?.contentsScale = scale
+			titleLayer.contentsScale = scale
+		}
+	}
+
+	private func setup() {
+		wantsLayer = true
+
+		layer?.masksToBounds = false
+
+		titleLayer.alignmentMode = .center
+		titleLayer.contentsScale = window?.backingScaleFactor ?? 2
+		layer?.addSublayer(titleLayer)
+		setTitle()
+
+		needsDisplay = true
+	}
+
+	public typealias ColorGenerator = () -> NSColor
+
+	private var colorGenerators = [KeyPath<CustomButton, NSColor>: ColorGenerator]()
+
+	/// Gets or sets the color generation closure for the provided key path.
+	///
+	/// - Parameter keyPath: The key path that specifies the color related property.
+	subscript (colorGenerator keyPath: KeyPath<CustomButton, NSColor>) -> ColorGenerator? {
+		get {
+			return colorGenerators[keyPath]
+		}
+		set {
+			colorGenerators[keyPath] = newValue
+		}
+	}
+
+	private func color(for keyPath: KeyPath<CustomButton, NSColor>) -> NSColor {
+		return colorGenerators[keyPath]?() ?? self[keyPath: keyPath]
+	}
+
+	override open func updateLayer() {
+		let isOn = state == .on
+		layer?.cornerRadius = CGFloat(cornerRadius)
+		layer?.borderWidth = CGFloat(borderWidth)
+		layer?.shadowRadius = CGFloat(isOn && activeShadowRadius != -1 ? activeShadowRadius : shadowRadius)
+		layer?.shadowOpacity = Float(isOn && activeShadowOpacity != -1 ? activeShadowOpacity : shadowOpacity)
+		animateColor()
+	}
+
+	private func setTitle() {
+		titleLayer.string = title
+
+		if let font = font {
+			titleLayer.font = font
+			titleLayer.fontSize = font.pointSize
+		}
+
+		needsLayout = true
+	}
+
+	private func positionTitle() {
+		let titleSize = title.size(withAttributes: [.font: font as Any])
+		titleLayer.frame = titleSize.centered(in: bounds).roundedOrigin()
+	}
+
+	private func animateColor() {
+		let isOn = state == .on
+		let duration = isOn ? 0.2 : 0.1
+		let backgroundColor = isOn ? color(for: \.activeBackgroundColor) : color(for: \.backgroundColor)
+		let textColor = isOn ? color(for: \.activeTextColor) : color(for: \.textColor)
+		let borderColor = isOn ? color(for: \.activeBorderColor) : color(for: \.borderColor)
+		let shadowColor = isOn ? (activeShadowColor ?? color(for: \.shadowColor)) : color(for: \.shadowColor)
+
+		layer?.animate(color: backgroundColor.cgColor, keyPath: #keyPath(CALayer.backgroundColor), duration: duration)
+		layer?.animate(color: borderColor.cgColor, keyPath: #keyPath(CALayer.borderColor), duration: duration)
+		layer?.animate(color: shadowColor.cgColor, keyPath: #keyPath(CALayer.shadowColor), duration: duration)
+		titleLayer.animate(color: textColor.cgColor, keyPath: #keyPath(CATextLayer.foregroundColor), duration: duration)
+	}
+
+	private func toggleState() {
+		state = state == .off ? .on : .off
+		animateColor()
+	}
+
+	override open func hitTest(_ point: CGPoint) -> NSView? {
+		return isEnabled ? super.hitTest(point) : nil
+	}
+
+	override open func mouseDown(with event: NSEvent) {
+		isMouseDown = true
+		toggleState()
+	}
+
+	override open func mouseEntered(with event: NSEvent) {
+		if isMouseDown {
+			toggleState()
+		}
+	}
+
+	override open func mouseExited(with event: NSEvent) {
+		if isMouseDown {
+			toggleState()
+			isMouseDown = false
+		}
+	}
+
+	override open func mouseUp(with event: NSEvent) {
+		if isMouseDown {
+			isMouseDown = false
+			toggleState()
+			_ = target?.perform(action, with: self)
+		}
+	}
+}
+
+extension CustomButton: NSViewLayerContentScaleDelegate {
+	private func layer(_ layer: CALayer, shouldInheritContentsScale newScale: CGFloat, from window: NSWindow) -> Bool {
+		return true
+	}
+}

--- a/Sources/CircularProgress/util.swift
+++ b/Sources/CircularProgress/util.swift
@@ -314,7 +314,7 @@ extension NSControl {
 	let button = NSButton(title: "Unicorn", target: nil, action: nil)
 
 	button.onAction = { sender in
-	print("Button action: \(sender)")
+		print("Button action: \(sender)")
 	}
 	```
 	*/
@@ -337,7 +337,7 @@ extension NSView {
 		timingFunction: CAMediaTimingFunction = .default,
 		animations: @escaping (() -> Void),
 		completion: (() -> Void)? = nil
-		) {
+	) {
 		DispatchQueue.main.asyncAfter(duration: delay) {
 			NSAnimationContext.runAnimationGroup({ context in
 				context.allowsImplicitAnimation = true
@@ -356,7 +356,7 @@ extension NSView {
 			delay: delay,
 			animations: {
 				self.isHidden = false
-		},
+			},
 			completion: completion
 		)
 	}

--- a/Sources/CircularProgress/util.swift
+++ b/Sources/CircularProgress/util.swift
@@ -284,3 +284,80 @@ extension NSBezierPath {
 		self.init(roundedRect: rect, xRadius: cornerRadius, yRadius: cornerRadius)
 	}
 }
+
+final class AssociatedObject<T: Any> {
+	subscript(index: Any) -> T? {
+		get {
+			return objc_getAssociatedObject(index, Unmanaged.passUnretained(self).toOpaque()) as! T?
+		} set {
+			objc_setAssociatedObject(index, Unmanaged.passUnretained(self).toOpaque(), newValue, .OBJC_ASSOCIATION_RETAIN_NONATOMIC)
+		}
+	}
+}
+
+extension NSControl {
+	typealias ActionClosure = ((NSControl) -> Void)
+
+	private struct AssociatedKeys {
+		static let onActionClosure = AssociatedObject<ActionClosure>()
+	}
+
+	@objc
+	private func callClosure(_ sender: NSControl) {
+		onAction?(sender)
+	}
+
+	/**
+	Closure version of `.action`
+
+	```
+	let button = NSButton(title: "Unicorn", target: nil, action: nil)
+
+	button.onAction = { sender in
+	print("Button action: \(sender)")
+	}
+	```
+	*/
+	var onAction: ActionClosure? {
+		get {
+			return AssociatedKeys.onActionClosure[self]
+		}
+		set {
+			AssociatedKeys.onActionClosure[self] = newValue
+			action = #selector(callClosure)
+			target = self
+		}
+	}
+}
+
+extension NSView {
+	static func animate(
+		duration: TimeInterval = 1,
+		delay: TimeInterval = 0,
+		timingFunction: CAMediaTimingFunction = .default,
+		animations: @escaping (() -> Void),
+		completion: (() -> Void)? = nil
+		) {
+		DispatchQueue.main.asyncAfter(duration: delay) {
+			NSAnimationContext.runAnimationGroup({ context in
+				context.allowsImplicitAnimation = true
+				context.duration = duration
+				context.timingFunction = timingFunction
+				animations()
+			}, completionHandler: completion)
+		}
+	}
+
+	func fadeIn(duration: TimeInterval = 1, delay: TimeInterval = 0, completion: (() -> Void)? = nil) {
+		isHidden = true
+
+		NSView.animate(
+			duration: duration,
+			delay: delay,
+			animations: {
+				self.isHidden = false
+		},
+			completion: completion
+		)
+	}
+}

--- a/readme.md
+++ b/readme.md
@@ -86,7 +86,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 }
 ```
 
-Setting a `Progress` object that `isCancellable` automatically enables the cancel button.
+Setting a `Progress` object that is [`isCancellable`](https://developer.apple.com/documentation/foundation/progress/1409348-iscancellable) automatically enables the cancel button.
+
 
 ## API
 

--- a/readme.md
+++ b/readme.md
@@ -124,27 +124,27 @@ func resetProgress() {}
 /**
 Cancels `Progress` if it's set and prevents further updates.
 */
-public func cancelProgress() {}
+func cancelProgress() {}
 
 /**
 Triggers when the progress was cancelled succesfully.
 */
-public var onCancelled: (() -> Void)?
+var onCancelled: (() -> Void)?
 
 /**
 Returns whether the progress is finished.
 */
-@IBInspectable public private(set) var isFinished: Bool
+@IBInspectable private(set) var isFinished: Bool
 
 /**
 If the progress view is cancellable it shows the cancel button.
 */
-@IBInspectable public var isCancellable: Bool
+@IBInspectable var isCancellable: Bool
 
 /**
 Returns whether the progress has been cancelled.
 */
-@IBInspectable public private(set) var isCancelled: Bool
+@IBInspectable private(set) var isCancelled: Bool
 
 init(frame: CGRect) {}
 init?(coder: NSCoder) {}

--- a/readme.md
+++ b/readme.md
@@ -86,6 +86,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 }
 ```
 
+Setting a `Progress` object that `isCancellable` automatically enables the cancel button.
 
 ## API
 

--- a/readme.md
+++ b/readme.md
@@ -121,6 +121,31 @@ Reset the progress back to zero without animating.
 */
 func resetProgress() {}
 
+/**
+Cancels `Progress` if it's set and prevents further updates.
+*/
+public func cancelProgress() {}
+
+/**
+Triggers when the progress was cancelled succesfully.
+*/
+public var onCancelled: (() -> Void)?
+
+/**
+Returns whether the progress is finished.
+*/
+@IBInspectable public private(set) var isFinished: Bool
+
+/**
+If the progress view is cancellable it shows the cancel button.
+*/
+@IBInspectable public var isCancellable: Bool
+
+/**
+Returns whether the progress has been cancelled.
+*/
+@IBInspectable public private(set) var isCancelled: Bool
+
 init(frame: CGRect) {}
 init?(coder: NSCoder) {}
 


### PR DESCRIPTION
Brings over the cancel functionality added to Gifski recently.

![cancel](https://user-images.githubusercontent.com/225410/51617966-a2649180-1f2d-11e9-8049-dd826cc65c86.gif)

I chose to copy over the `CustomButton` verbatim. Using it here might help fleshing out how it should behave as a standalone component later.

The cancel button currently only appears when a `Progress` instance has been set that is `isCancellable`.