### PR TITLE
Add tracking area to custom button

### DIFF
--- a/Sources/CircularProgress/CustomButton.swift
+++ b/Sources/CircularProgress/CustomButton.swift
@@ -215,6 +215,8 @@ open class CustomButton: NSButton {
 	private var trackingArea: NSTrackingArea?
 
 	override open func updateTrackingAreas() {
+		super.updateTrackingAreas()
+
 		if let oldTrackingArea = trackingArea {
 			removeTrackingArea(oldTrackingArea)
 		}

--- a/Sources/CircularProgress/CustomButton.swift
+++ b/Sources/CircularProgress/CustomButton.swift
@@ -212,6 +212,27 @@ open class CustomButton: NSButton {
 		}
 	}
 
+	private var trackingArea: NSTrackingArea?
+
+	override open func updateTrackingAreas() {
+		if let oldTrackingArea = trackingArea {
+			removeTrackingArea(oldTrackingArea)
+		}
+
+		let newTrackingArea = NSTrackingArea(
+			rect: bounds,
+			options: [
+				.mouseEnteredAndExited,
+				.activeInActiveApp
+			],
+			owner: self,
+			userInfo: nil
+		)
+
+		addTrackingArea(newTrackingArea)
+		trackingArea = newTrackingArea
+	}
+
 	private func setup() {
 		wantsLayer = true
 


### PR DESCRIPTION
Resolves https://github.com/sindresorhus/CircularProgress/pull/4#issuecomment-458431791

We could probably use the tracking area in the `CircularProgress` view as well, but that would require customizing `CustomButton` just for this.