### PR TITLE
Ensure `.isHidden` is set on the main thread

### DIFF
--- a/Sources/CircularProgress/CircularProgress.swift
+++ b/Sources/CircularProgress/CircularProgress.swift
@@ -3,7 +3,8 @@ import Cocoa
 @IBDesignable
 public final class CircularProgress: NSView {
 	private var lineWidth: Double = 2
-	private lazy var radius = bounds.width < bounds.height ? bounds.midX * 0.8 : bounds.midY * 0.8
+	// TODO: Remove the closure here when targeting Swift 5
+	private lazy var radius = { bounds.width < bounds.height ? bounds.midX * 0.8 : bounds.midY * 0.8 }()
 	private var _progress: Double = 0
 	private var progressObserver: NSKeyValueObservation?
 	private var finishedObserver: NSKeyValueObservation?

--- a/Sources/CircularProgress/CircularProgress.swift
+++ b/Sources/CircularProgress/CircularProgress.swift
@@ -67,6 +67,7 @@ public final class CircularProgress: NSView {
 	The progress value in the range `0...1`.
 
 	- Note: The value will be clamped to `0...1`.
+	- Note: Can be set from a background thread.
 	*/
 	@IBInspectable public var progress: Double {
 		get {

--- a/Sources/CircularProgress/CircularProgress.swift
+++ b/Sources/CircularProgress/CircularProgress.swift
@@ -79,7 +79,9 @@ public final class CircularProgress: NSView {
 				self.progressCircle.progress = self._progress
 			})
 
-			progressLabel.isHidden = progress == 0 && isIndeterminate ? cancelButton.isHidden : !cancelButton.isHidden
+			DispatchQueue.main.async {
+				self.progressLabel.isHidden = self.progress == 0 && self.isIndeterminate ? self.cancelButton.isHidden : !self.cancelButton.isHidden
+			}
 
 			if !progressLabel.isHidden {
 				progressLabel.string = "\(Int(_progress * 100))%"

--- a/readme.md
+++ b/readme.md
@@ -127,6 +127,7 @@ Show `✔` instead `100%`.
 The progress value in the range `0...1`.
 
 - Note: The value will be clamped to `0...1`.
+- Note: Can be set from a background thread.
 */
 @IBInspectable var progress: Double = 0
 


### PR DESCRIPTION
I noticed the progress could be updated from a background thread. Toggling `isHidden` without switching to the main thread will throw warnings in the console.