### PR TITLE
Fix resetting color and variable scope

### DIFF
--- a/Example/AppDelegate.swift
+++ b/Example/AppDelegate.swift
@@ -27,7 +27,6 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 		animateWithRandomColor(
 			manualCircularProgress,
 			start: { circularProgress in
-				circularProgress.alphaValue = 1
 				circularProgress.resetProgress()
 			},
 			tick: { circularProgress in
@@ -40,7 +39,6 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 		animateWithRandomColor(
 			progressCircularProgress,
 			start: { circularProgress in
-				circularProgress.alphaValue = 1
 				circularProgress.resetProgress()
 
 				let progress = Progress(totalUnitCount: 50)

--- a/Sources/CircularProgress/CircularProgress.swift
+++ b/Sources/CircularProgress/CircularProgress.swift
@@ -184,10 +184,10 @@ public final class CircularProgress: NSView {
 	}
 
 	override public func updateLayer() {
-		updateColors()
+		updateColors(with: color)
 	}
 
-	private func updateColors() {
+	private func updateColors(with color: NSColor) {
 		let duration = 0.2
 
 		backgroundCircle.animate(color: color.with(alpha: 0.5).cgColor, keyPath: #keyPath(CAShapeLayer.strokeColor), duration: duration)
@@ -229,8 +229,9 @@ public final class CircularProgress: NSView {
 		isIndeterminate = false
 		progressCircle.resetProgress()
 		progressLabel.string = "0%"
-
 		alphaValue = 1
+
+		needsDisplay = true
 	}
 
 	/**
@@ -310,14 +311,15 @@ public final class CircularProgress: NSView {
 			return
 		}
 
+		let cancelledColor: NSColor
 		if let colorHandler = cancelledStateColorHandler {
-			color = colorHandler(color)
+			cancelledColor = colorHandler(color)
 		} else {
-			color = color.adjusting(saturation: -0.4, brightness: -0.2)
+			cancelledColor = color.adjusting(saturation: -0.4, brightness: -0.2)
 			alphaValue = 0.7
 		}
 
-		updateColors()
+		updateColors(with: cancelledColor)
 	}
 
 	private var trackingArea: NSTrackingArea?

--- a/Sources/CircularProgress/CircularProgress.swift
+++ b/Sources/CircularProgress/CircularProgress.swift
@@ -47,13 +47,21 @@ public final class CircularProgress: NSView {
 		}
 	}
 
+	private var originalColor: NSColor = .controlAccentColorPolyfill
+	private var _color: NSColor = .controlAccentColorPolyfill
 	/**
 	Color of the circular progress view.
 
 	Defaults to the user's accent color. For High Sierra and below it uses a fallback color.
 	*/
-	@IBInspectable public var color: NSColor = .controlAccentColorPolyfill {
-		didSet {
+	@IBInspectable public var color: NSColor {
+		get {
+			return _color
+		}
+		set {
+			_color = newValue
+			originalColor = newValue
+
 			needsDisplay = true
 		}
 	}
@@ -184,12 +192,11 @@ public final class CircularProgress: NSView {
 	}
 
 	override public func updateLayer() {
-		updateColors(with: color)
+		updateColors()
 	}
 
-	private func updateColors(with color: NSColor) {
+	private func updateColors() {
 		let duration = 0.2
-
 		backgroundCircle.animate(color: color.with(alpha: 0.5).cgColor, keyPath: #keyPath(CAShapeLayer.strokeColor), duration: duration)
 
 		progressCircle.animate(color: color.cgColor, keyPath: #keyPath(CAShapeLayer.strokeColor), duration: duration)
@@ -223,13 +230,17 @@ public final class CircularProgress: NSView {
 	Reset the progress back to zero without animating.
 	*/
 	public func resetProgress() {
+		alphaValue = 1
+
+		_color = originalColor
 		_progress = 0
+
 		_isFinished = false
 		_isCancelled = false
 		isIndeterminate = false
+
 		progressCircle.resetProgress()
 		progressLabel.string = "0%"
-		alphaValue = 1
 
 		needsDisplay = true
 	}
@@ -311,15 +322,14 @@ public final class CircularProgress: NSView {
 			return
 		}
 
-		let cancelledColor: NSColor
 		if let colorHandler = cancelledStateColorHandler {
-			cancelledColor = colorHandler(color)
+			_color = colorHandler(originalColor)
 		} else {
-			cancelledColor = color.adjusting(saturation: -0.4, brightness: -0.2)
+			_color = originalColor.adjusting(saturation: -0.4, brightness: -0.2)
 			alphaValue = 0.7
 		}
 
-		updateColors(with: cancelledColor)
+		needsDisplay = true
 	}
 
 	private var trackingArea: NSTrackingArea?

--- a/Sources/CircularProgress/CircularProgress.swift
+++ b/Sources/CircularProgress/CircularProgress.swift
@@ -254,7 +254,7 @@ public final class CircularProgress: NSView {
 	*/
 	public var onCancelled: (() -> Void)?
 
-	public var _isCancellable = false
+	private var _isCancellable = false
 	/**
 	If the progress view is cancellable it shows the cancel button.
 	*/


### PR DESCRIPTION
Fixes #14 
Fixes #15

I tried a few things to reset the color after cancelling the progress. This seems to be the least obtrusive and avoids adding variables like `originalColor` etc. I think it fits the temporary nature of the color change.