### PR TITLE
Use strongly-typed key paths internally

### DIFF
--- a/Sources/CircularProgress/CircularProgress.swift
+++ b/Sources/CircularProgress/CircularProgress.swift
@@ -228,12 +228,10 @@ public final class CircularProgress: NSView {
 
 	private func updateColors() {
 		let duration = 0.2
-		backgroundCircle.animate(color: color.withAlpha(0.5).cgColor, keyPath: \.strokeColor, duration: duration)
-
-		progressCircle.animate(color: color.cgColor, keyPath: \.strokeColor, duration: duration)
-		progressLabel.animate(color: color.cgColor, keyPath: \.foregroundColor, duration: duration)
-
-		indeterminateCircle.animate(color: color.cgColor, keyPath: \.strokeColor, duration: duration)
+		backgroundCircle.animate(\.strokeColor, to: color.withAlpha(0.5), duration: duration)
+		progressCircle.animate(\.strokeColor, to: color, duration: duration)
+		progressLabel.animate(\.foregroundColor, to: color, duration: duration)
+		indeterminateCircle.animate(\.strokeColor, to: color, duration: duration)
 
 		cancelButton.textColor = color
 		cancelButton.backgroundColor = color.withAlpha(0.1)

--- a/Sources/CircularProgress/CircularProgress.swift
+++ b/Sources/CircularProgress/CircularProgress.swift
@@ -228,12 +228,12 @@ public final class CircularProgress: NSView {
 
 	private func updateColors() {
 		let duration = 0.2
-		backgroundCircle.animate(color: color.withAlpha(0.5).cgColor, keyPath: #keyPath(CAShapeLayer.strokeColor), duration: duration)
+		backgroundCircle.animate(color: color.withAlpha(0.5).cgColor, keyPath: \.strokeColor, duration: duration)
 
-		progressCircle.animate(color: color.cgColor, keyPath: #keyPath(CAShapeLayer.strokeColor), duration: duration)
-		progressLabel.animate(color: color.cgColor, keyPath: #keyPath(CATextLayer.foregroundColor), duration: duration)
+		progressCircle.animate(color: color.cgColor, keyPath: \.strokeColor, duration: duration)
+		progressLabel.animate(color: color.cgColor, keyPath: \.foregroundColor, duration: duration)
 
-		indeterminateCircle.animate(color: color.cgColor, keyPath: #keyPath(CAShapeLayer.strokeColor), duration: duration)
+		indeterminateCircle.animate(color: color.cgColor, keyPath: \.strokeColor, duration: duration)
 
 		cancelButton.textColor = color
 		cancelButton.backgroundColor = color.withAlpha(0.1)

--- a/Sources/CircularProgress/Vendored/CustomButton+Util.swift
+++ b/Sources/CircularProgress/Vendored/CustomButton+Util.swift
@@ -78,13 +78,14 @@ final class AnimationDelegate: NSObject, CAAnimationDelegate {
 protocol LayerColorAnimation: AnyObject {}
 extension LayerColorAnimation where Self: CALayer {
 	func animate(_ keyPath: ReferenceWritableKeyPath<Self, CGColor?>, to color: CGColor, duration: Double) {
-		let keyPathStr = NSExpression(forKeyPath: keyPath).keyPath
-		let animation = CABasicAnimation(keyPath: keyPathStr)
+		let keyPathString = NSExpression(forKeyPath: keyPath).keyPath
+		let animation = CABasicAnimation(keyPath: keyPathString)
 		animation.fromValue = self[keyPath: keyPath]
 		animation.toValue = color
 		animation.duration = duration
 		animation.fillMode = .forwards
 		animation.isRemovedOnCompletion = false
+
 		add(animation, forKeyPath: keyPath) { [weak self] _ in
 			self?[keyPath: keyPath] = color
 		}
@@ -95,11 +96,11 @@ extension LayerColorAnimation where Self: CALayer {
 	}
 	
 	func add(_ animation: CAAnimation, forKeyPath keyPath: ReferenceWritableKeyPath<Self, CGColor?>, completion: @escaping ((Bool) -> Void)) {
-		let keyPathStr = NSExpression(forKeyPath: keyPath).keyPath
+		let keyPathString = NSExpression(forKeyPath: keyPath).keyPath
 		let animationDelegate = AnimationDelegate()
 		animationDelegate.didStopHandler = completion
 		animation.delegate = animationDelegate
-		add(animation, forKey: keyPathStr)
+		add(animation, forKey: keyPathString)
 	}
 }
 

--- a/Sources/CircularProgress/Vendored/CustomButton+Util.swift
+++ b/Sources/CircularProgress/Vendored/CustomButton+Util.swift
@@ -90,11 +90,11 @@ extension LayerColorAnimation where Self: CALayer {
 			self?[keyPath: keyPath] = color
 		}
 	}
-	
+
 	func animate(_ keyPath: ReferenceWritableKeyPath<Self, CGColor?>, to color: NSColor, duration: Double) {
 		animate(keyPath, to: color.cgColor, duration: duration)
 	}
-	
+
 	func add(_ animation: CAAnimation, forKeyPath keyPath: ReferenceWritableKeyPath<Self, CGColor?>, completion: @escaping ((Bool) -> Void)) {
 		let keyPathString = NSExpression(forKeyPath: keyPath).keyPath
 		let animationDelegate = AnimationDelegate()

--- a/Sources/CircularProgress/Vendored/CustomButton+Util.swift
+++ b/Sources/CircularProgress/Vendored/CustomButton+Util.swift
@@ -77,7 +77,7 @@ final class AnimationDelegate: NSObject, CAAnimationDelegate {
 
 protocol LayerColorAnimation: AnyObject {}
 extension LayerColorAnimation where Self: CALayer {
-	func animate(color: CGColor, keyPath: ReferenceWritableKeyPath<Self, CGColor?>, duration: Double) {
+	func animate(_ keyPath: ReferenceWritableKeyPath<Self, CGColor?>, to color: CGColor, duration: Double) {
 		let keyPathStr = NSExpression(forKeyPath: keyPath).keyPath
 		let animation = CABasicAnimation(keyPath: keyPathStr)
 		animation.fromValue = self[keyPath: keyPath]
@@ -85,21 +85,26 @@ extension LayerColorAnimation where Self: CALayer {
 		animation.duration = duration
 		animation.fillMode = .forwards
 		animation.isRemovedOnCompletion = false
-		add(animation, forKey: keyPathStr) { [weak self] _ in
+		add(animation, forKeyPath: keyPath) { [weak self] _ in
 			self?[keyPath: keyPath] = color
 		}
 	}
-}
-
-
-extension CALayer: LayerColorAnimation {
-	func add(_ animation: CAAnimation, forKey key: String?, completion: @escaping ((Bool) -> Void)) {
+	
+	func animate(_ keyPath: ReferenceWritableKeyPath<Self, CGColor?>, to color: NSColor, duration: Double) {
+		animate(keyPath, to: color.cgColor, duration: duration)
+	}
+	
+	func add(_ animation: CAAnimation, forKeyPath keyPath: ReferenceWritableKeyPath<Self, CGColor?>, completion: @escaping ((Bool) -> Void)) {
+		let keyPathStr = NSExpression(forKeyPath: keyPath).keyPath
 		let animationDelegate = AnimationDelegate()
 		animationDelegate.didStopHandler = completion
 		animation.delegate = animationDelegate
-		add(animation, forKey: key)
+		add(animation, forKey: keyPathStr)
 	}
 }
+
+
+extension CALayer: LayerColorAnimation {}
 
 
 extension CGPoint {

--- a/Sources/CircularProgress/Vendored/CustomButton.swift
+++ b/Sources/CircularProgress/Vendored/CustomButton.swift
@@ -239,11 +239,11 @@ open class CustomButton: NSButton {
 		let textColor = isOn ? color(for: \.activeTextColor) : color(for: \.textColor)
 		let borderColor = isOn ? color(for: \.activeBorderColor) : color(for: \.borderColor)
 		let shadowColor = isOn ? (activeShadowColor ?? color(for: \.shadowColor)) : color(for: \.shadowColor)
-
-		layer?.animate(color: backgroundColor.cgColor, keyPath: \.backgroundColor, duration: duration)
-		layer?.animate(color: borderColor.cgColor, keyPath: \.borderColor, duration: duration)
-		layer?.animate(color: shadowColor.cgColor, keyPath: \.shadowColor, duration: duration)
-		titleLayer.animate(color: textColor.cgColor, keyPath: \.foregroundColor, duration: duration)
+		
+		layer?.animate(\.backgroundColor, to: backgroundColor, duration: duration)
+		layer?.animate(\.borderColor, to: borderColor, duration: duration)
+		layer?.animate(\.shadowColor, to: shadowColor, duration: duration)
+		titleLayer.animate(\.foregroundColor, to: textColor, duration: duration)
 	}
 
 	private func toggleState() {

--- a/Sources/CircularProgress/Vendored/CustomButton.swift
+++ b/Sources/CircularProgress/Vendored/CustomButton.swift
@@ -239,7 +239,7 @@ open class CustomButton: NSButton {
 		let textColor = isOn ? color(for: \.activeTextColor) : color(for: \.textColor)
 		let borderColor = isOn ? color(for: \.activeBorderColor) : color(for: \.borderColor)
 		let shadowColor = isOn ? (activeShadowColor ?? color(for: \.shadowColor)) : color(for: \.shadowColor)
-		
+
 		layer?.animate(\.backgroundColor, to: backgroundColor, duration: duration)
 		layer?.animate(\.borderColor, to: borderColor, duration: duration)
 		layer?.animate(\.shadowColor, to: shadowColor, duration: duration)

--- a/Sources/CircularProgress/Vendored/CustomButton.swift
+++ b/Sources/CircularProgress/Vendored/CustomButton.swift
@@ -240,10 +240,10 @@ open class CustomButton: NSButton {
 		let borderColor = isOn ? color(for: \.activeBorderColor) : color(for: \.borderColor)
 		let shadowColor = isOn ? (activeShadowColor ?? color(for: \.shadowColor)) : color(for: \.shadowColor)
 
-		layer?.animate(color: backgroundColor.cgColor, keyPath: #keyPath(CALayer.backgroundColor), duration: duration)
-		layer?.animate(color: borderColor.cgColor, keyPath: #keyPath(CALayer.borderColor), duration: duration)
-		layer?.animate(color: shadowColor.cgColor, keyPath: #keyPath(CALayer.shadowColor), duration: duration)
-		titleLayer.animate(color: textColor.cgColor, keyPath: #keyPath(CATextLayer.foregroundColor), duration: duration)
+		layer?.animate(color: backgroundColor.cgColor, keyPath: \.backgroundColor, duration: duration)
+		layer?.animate(color: borderColor.cgColor, keyPath: \.borderColor, duration: duration)
+		layer?.animate(color: shadowColor.cgColor, keyPath: \.shadowColor, duration: duration)
+		titleLayer.animate(color: textColor.cgColor, keyPath: \.foregroundColor, duration: duration)
 	}
 
 	private func toggleState() {


### PR DESCRIPTION
Fixes #20 

I've done this, by declaring protocol where `Self` is constrained to `CALayer`, and implementing `animate` method with `Self` as KeyPath parameter. Works for base CALayer and its descendants.


<!-- Issuehunt content -->

---

<details>
<summary>
<b>IssueHunt Summary</b>
</summary>

### Referenced issues

This pull request has been submitted to:
- [#20: Use strongly-typed KeyPath in `CALayer#animate()`](https://issuehunt.io/repos/153606623/issues/20)
---

IssueHunt has been backed by the following sponsors. [Become a sponsor](https://issuehunt.io/membership/members)
</details>
<!-- /Issuehunt content-->